### PR TITLE
Fix component annotation for SecondDay

### DIFF
--- a/src/main/kotlin/com/fortyday/challenge/day2/SecondDay.kt
+++ b/src/main/kotlin/com/fortyday/challenge/day2/SecondDay.kt
@@ -1,6 +1,9 @@
 package com.fortyday.challenge.day2
 
-class SecondDay  {
+import org.springframework.stereotype.Component
+
+@Component
+class SecondDay {
 
     fun fibonacciSequence(i: Int): IntArray {
         val fibonacciArray = IntArray(i)


### PR DESCRIPTION
## Summary
- mark `SecondDay` as a Spring component so it can be injected in tests

## Testing
- `gradlew test --tests com.fortyday.challenge.day2.SecondDayTest` *(fails: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff0424dc8325adaa31a73626f324